### PR TITLE
Prepare for inclusion into nanoc org

### DIFF
--- a/lib/nanoc/external/filter.rb
+++ b/lib/nanoc/external/filter.rb
@@ -28,14 +28,17 @@ module Nanoc::External
     #   filter :external, exec: '/usr/local/bin/htmlcompressor
     def run(content, params = {})
       debug = params.fetch(:debug, false)
-      cmd = params.fetch(:exec, nil)
+      cmd   = params.fetch(:exec, nil)
+      opts  = params.fetch(:options, [])
+
       if cmd.nil?
         raise Nanoc::Errors::GenericTrivial.new("nanoc-external: missing :exec argument")
       end
-      cmd.concat(params.fetch(:options, []))
-      odebug(cmd.join(' ')) if debug
+
+      cmd_with_opts = [ cmd ] + opts
+      odebug(cmd_with_opts.join(' ')) if debug
       out = ''
-      IO.popen(cmd, mode='r+') do |io|
+      IO.popen(cmd_with_opts, mode='r+') do |io|
         io.write content
         io.close_write # let the process know you've given it all the data
         out = io.read

--- a/lib/nanoc/external/filter.rb
+++ b/lib/nanoc/external/filter.rb
@@ -1,12 +1,12 @@
 # encoding: utf-8
 
-module Nanoc::PluginTemplate
+module Nanoc::External
 
-  # Executes an arbitrary program.
-  # For this filter to work, the external program must be
-  # able to receive its input from STDIN and it must send its
-  # output to STDOUT.
-  class ExternalFilter < Nanoc::Filter
+  # Pipes content through an external process.
+  #
+  # For this filter to work, the external program must be able to receive input
+  # from standard input and it must write its output to standard output.
+  class Filter < Nanoc::Filter
 
     identifier :external
 

--- a/nanoc-external.gemspec
+++ b/nanoc-external.gemspec
@@ -24,7 +24,6 @@ Gem::Specification.new do |s|
   s.rdoc_options     = [ '--main', 'README.md' ]
   s.extra_rdoc_files = [ 'LICENSE', 'README.md', 'NEWS.md' ]
 
-  s.add_runtime_dependency('nanoc-core')
-  s.add_runtime_dependency('external')
+  s.add_runtime_dependency('nanoc', '>= 3.6.7', '< 4.0.0')
   s.add_development_dependency('bundler')
 end

--- a/nanoc-external.gemspec
+++ b/nanoc-external.gemspec
@@ -7,7 +7,7 @@ Gem::Specification.new do |s|
   s.name        = 'nanoc-external'
   s.version     = Nanoc::External::VERSION
   s.homepage    = 'http://nanoc.ws/'
-  s.summary     = 'Plugin template for nanoc'
+  s.summary     = 'Exernal filter for nanoc'
   s.description = 'Provides a :external filter for nanoc'
 
   s.author  = 'Lifepillar'

--- a/test/filters/test_external.rb
+++ b/test/filters/test_external.rb
@@ -4,19 +4,13 @@ require 'helper'
 
 class Nanoc::External::FilterTest < Minitest::Test
 
-  def test_filter_no_options
-    filter = ::Nanoc::External::Filter.new({})
-    src = "Shall I compare thee to a Summer's day?"
-    out = 'U2hhbGwgSSBjb21wYXJlIHRoZWUgdG8gYSBTdW1tZXIncyBkYXk/Cg=='
-    assert_equal(out, filter.run(src, :exec => '/usr/bin/base64'))
-  end
-
-  def test_filter_with_options
+  def test_filter
     filter = ::Nanoc::External::Filter.new({})
     src = <<-SHAKESPEARE
     Shall I compare thee to a Summer's day?
     Thou art more lovely and more temperate
     SHAKESPEARE
-    assert_match(/^\s*2\s*$/, filter.run(src, :exec => 'wc', :options => %w( -l ) ))  
+    assert_match(/^\s*2\s*$/, filter.run(src, :exec => 'wc', :options => %w( -l ) ))
   end
+
 end

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -2,5 +2,5 @@
 
 require 'minitest'
 require 'minitest/autorun'
-require 'nanoc-core'
+require 'nanoc'
 require 'nanoc-external'


### PR DESCRIPTION
This PR fixes a few small issues and makes the repo ready to be included in the nanoc organisation on GitHub.
- Removed mentions of the plugin template
- Fixed dependencies so they depend on the current version of nanoc, rather than nanoc 4.0.
- Fixed issue with arrays/strings in executing the command.
- Removed the base64 test, as it fails on my local machine, and I think a single test should be enough.
